### PR TITLE
Add a language option in `getIndividualGame` interface

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,10 +40,13 @@ class PSN {
         return http.get(option);
     }
 
-    getIndividualGame(npCommunicationId, onlineId, access_token) {
+    getIndividualGame(npCommunicationId, onlineId, access_token, options) {
+        // options: {
+        //     npLanguage: <language code>
+        // }
         const fields = {
             'fields': '@default,trophyRare,trophyEarnedRate',
-            'npLanguage': 'en',
+            'npLanguage': options.npLanguage ? options.npLanguage : 'en',
             'comparedUser': onlineId
         }
         const option = {

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ class PSN {
         // }
         const fields = {
             'fields': '@default,trophyRare,trophyEarnedRate',
-            'npLanguage': options.npLanguage ? options.npLanguage : 'en',
+            'npLanguage': options ? (options.npLanguage ? options.npLanguage : 'en') : 'en',
             'comparedUser': onlineId
         }
         const option = {


### PR DESCRIPTION
Add the international support for non-English user. The language option is optional, if leave it blank, it will fallback to `en` language when the interface getting the information.